### PR TITLE
Add support for testing SsoSilent login

### DIFF
--- a/src/MsalReactTester.ts
+++ b/src/MsalReactTester.ts
@@ -1,6 +1,23 @@
-import { IPublicClientApplication, Logger, LogLevel, AccountInfo, EventCallbackFunction, AuthenticationResult, EventMessage, EventType, InteractionType, AuthError } from '@azure/msal-browser';
-import { MsalReactTesterPlugin, ITestRunner } from './MsalReactTesterPlugin';
-import { defaultTestAccountInfo, defaultTestAuthenticationResult, defaultTestAuthError, } from './testerConstants';
+import {
+  IPublicClientApplication,
+  Logger,
+  LogLevel,
+  AccountInfo,
+  EventCallbackFunction,
+  AuthenticationResult,
+  EventMessage,
+  EventType,
+  InteractionType,
+  AuthError,
+  BrowserConfiguration,
+} from "@azure/msal-browser";
+import { MsalReactTesterPlugin, ITestRunner } from "./MsalReactTesterPlugin";
+import {
+  defaultTestAccountInfo,
+  defaultTestAuthenticationResult,
+  defaultTestAuthError,
+} from "./testerConstants";
+import { ITokenCache } from "@azure/msal-browser/dist/cache/ITokenCache";
 /**
  * msal-react tester. Useful to tests your components requiring to be logged in, using msal-react
  * @example
@@ -34,119 +51,137 @@ import { defaultTestAccountInfo, defaultTestAuthenticationResult, defaultTestAut
 
  */
 class MsalReactTester {
+  private _eventCallbacks: EventCallbackFunction[] = [];
+  private _handleRedirectSpy: any;
+  private _loginRedirectSpy: any;
+  private _loginPopupSpy: any;
+  private _ssoSilentSpy: any;
+  private _logoutRedirectSpy: any;
+  private _logoutPopupSpy: any;
+  private _testAccountInfo: AccountInfo;
+  private _testAuthenticationResult: AuthenticationResult;
+  private _testRunner: ITestRunner;
 
-	private _eventCallbacks: EventCallbackFunction[] = [];
-	private _handleRedirectSpy: any;
-	private _loginRedirectSpy: any;
-	private _loginPopupSpy: any;
-	private _logoutRedirectSpy: any;
-	private _logoutPopupSpy: any;
-	private _testAccountInfo: AccountInfo;
-	private _testAuthenticationResult: AuthenticationResult;
-	private _testRunner: ITestRunner
+  client: IPublicClientApplication;
+  accounts: AccountInfo[] = [];
+  activeAccount: AccountInfo | null = null;
+  error: AuthError;
 
-	client: IPublicClientApplication;
-	accounts: AccountInfo[] = [];
-	activeAccount: AccountInfo | null = null;
-	error: AuthError;
+  /**
+   * Create a new mock IPublicClientApplication instance
+   * @param testAccountInfo test account you want to use. A default is created if null
+   * @param testAuthenticationResult test authentication result you want to use . A default is created if null
+   */
+  constructor(
+    public interationType: "Redirect" | "Popup" | "Silent" = "Redirect",
+    testAccountInfo = defaultTestAccountInfo,
+    testAuthenticationResult = defaultTestAuthenticationResult,
+    testAuthError = defaultTestAuthError
+  ) {
+    this._testRunner = MsalReactTesterPlugin.TestRunner;
 
-	/**
-	 * Create a new mock IPublicClientApplication instance
-	 * @param testAccountInfo test account you want to use. A default is created if null
-	 * @param testAuthenticationResult test authentication result you want to use . A default is created is null
-	 */
-	constructor(public interationType: 'Redirect' | 'Popup' = 'Redirect', testAccountInfo = defaultTestAccountInfo,
-		testAuthenticationResult = defaultTestAuthenticationResult,
-		testAuthError = defaultTestAuthError) {
+    this._testAccountInfo = testAccountInfo;
+    this._testAuthenticationResult = testAuthenticationResult;
 
-		this._testRunner = MsalReactTesterPlugin.TestRunner;
+    this.error = testAuthError;
+    this.client = MsalReactTester.GetNewClient(
+      testAccountInfo,
+      testAuthenticationResult
+    );
+  }
 
+  async actAwait(interval?: number): Promise<void> {
+    let awaiter = (interval?: number): Promise<void> =>
+      new Promise((r, s) => setTimeout(r, interval));
+    await awaiter(interval);
+  }
 
-		this._testAccountInfo = testAccountInfo;
-		this._testAuthenticationResult = testAuthenticationResult;
+  /**
+   * Initialize the IPublicClientApplication with an active account.
+   */
+  async isLogged() {
+    this.accounts = [this._testAccountInfo];
+    this.activeAccount = this._testAccountInfo;
+    // ensuring that render (that should come right after) will not be too fast
+    // and raise an error with act() => ....
+    await this.actAwait(1);
+  }
 
-		this.error = testAuthError;
-		this.client = MsalReactTester.GetNewClient(testAccountInfo, testAuthenticationResult)
-	}
+  /**
+   * Initialize the IPublicClientApplication with no active account
+   */
+  async isNotLogged() {
+    this.accounts = [];
+    this.activeAccount = null;
+    // ensuring that render (that should come right after) will not be too fast
+    // and raise an error with act() => ....
+    await this.actAwait(1);
+  }
 
-	async actAwait(interval?: number): Promise<void>
-	{
-		let awaiter = (interval?: number): Promise<void> => new Promise((r, s) => setTimeout(r, interval));
-		await awaiter(interval);
-	}
+  /**
+   * Reset all spy / mocks. Should be used in `afterEach` call:
+   *
+   *  @example
+   *  afterEach(() => {
+   *   msalTester.resetSpyMsal();
+   * });
+   */
+  resetSpyMsal() {
+    this._testRunner.resetAllMocks();
+    this.accounts = [];
+    this.activeAccount = null;
+    this._eventCallbacks = [];
+  }
 
+  /**
+   * Wait for login process to be done
+   */
+  async waitForLogin() {
+    await this._testRunner.waitingFor(() =>
+      this._testRunner.expect(this._handleRedirectSpy).toHaveBeenCalledTimes(1)
+    );
+    if (this.interationType === "Redirect")
+      await this._testRunner.waitingFor(() =>
+        this._testRunner.expect(this._loginRedirectSpy).toHaveBeenCalledTimes(1)
+      );
+    else if (this.interationType === "Popup")
+      await this._testRunner.waitingFor(() =>
+        this._testRunner.expect(this._loginPopupSpy).toHaveBeenCalledTimes(1)
+      );
+    else
+      await this._testRunner.waitingFor(() =>
+        this._testRunner.expect(this._ssoSilentSpy).toHaveBeenCalledTimes(1)
+      );
+  }
 
-	/**
-	 * Initialize the IPublicClientApplication with an active account.
-	 */
-	async isLogged() {
-		this.accounts = [this._testAccountInfo];
-		this.activeAccount = this._testAccountInfo;
-		// ensuring that render (that should come right after) will not be too fast
-		// and raise an error with act() => ....
-		await this.actAwait(1);
+  /**
+   * Wait for redirect handled by MSAL to be done
+   */
+  async waitForRedirect() {
+    await this._testRunner.waitingFor(() =>
+      this._testRunner.expect(this._handleRedirectSpy).toHaveBeenCalledTimes(1)
+    );
+  }
 
-	}
+  /**
+   * Wait for logout process to be done
+   */
+  async waitForLogout() {
+    await this._testRunner.waitingFor(() =>
+      this._testRunner.expect(this._handleRedirectSpy).toHaveBeenCalledTimes(1)
+    );
 
-	/**
-	 * Initialize the IPublicClientApplication with no active account
-	 */
-	async isNotLogged() {
+    if (this.interationType === "Redirect" || this.interationType === "Silent")
+      await this._testRunner.waitingFor(() =>
+        this._testRunner.expect(this._logoutRedirectSpy).toHaveBeenCalledTimes(1)
+      );
+    else
+      await this._testRunner.waitingFor(() =>
+        this._testRunner.expect(this._logoutPopupSpy).toHaveBeenCalledTimes(1)
+      );
+  }
 
-		this.accounts = [];
-		this.activeAccount = null;
-		// ensuring that render (that should come right after) will not be too fast
-		// and raise an error with act() => ....
-		await this.actAwait(1);
-
-	}
-
-	/**
-	 * Reset all spy / mocks. Should be used in `afterEach` call:
-	 * 
-	 *  @example
-	 *  afterEach(() => {
-	 *   msalTester.resetSpyMsal();
-	 * });
-	 */
-	resetSpyMsal() {
-		this._testRunner.resetAllMocks();
-		this.accounts = [];
-		this.activeAccount = null;
-		this._eventCallbacks = [];
-	}
-
-	/**
-	 * Wait for login process to be done
-	 */
-	async waitForLogin() {
-		await this._testRunner.waitingFor(() => this._testRunner.expect(this._handleRedirectSpy).toHaveBeenCalledTimes(1));
-		if (this.interationType === 'Redirect')
-			await this._testRunner.waitingFor(() => this._testRunner.expect(this._loginRedirectSpy).toHaveBeenCalledTimes(1));
-		else
-			await this._testRunner.waitingFor(() => this._testRunner.expect(this._loginPopupSpy).toHaveBeenCalledTimes(1));
-	}
-
-	/**
-	 * Wait for redirect handled by MSAL to be done
-	 */
-	async waitForRedirect() {
-		await this._testRunner.waitingFor(() => this._testRunner.expect(this._handleRedirectSpy).toHaveBeenCalledTimes(1));
-	}
-
-	/**
-	 * Wait for logout process to be done
-	 */
-	async waitForLogout() {
-		await this._testRunner.waitingFor(() => this._testRunner.expect(this._handleRedirectSpy).toHaveBeenCalledTimes(1));
-
-		if (this.interationType === 'Redirect')
-			await this._testRunner.waitingFor(() => this._testRunner.expect(this._logoutRedirectSpy).toHaveBeenCalledTimes(1));
-		else
-			await this._testRunner.waitingFor(() => this._testRunner.expect(this._logoutPopupSpy).toHaveBeenCalledTimes(1));
-	}
-
-	/**
+  /**
 	* Spy and Mocks required MSAL things. Should be used in `beforeEach` call:
 	* 
 	*  @example
@@ -159,224 +194,291 @@ class MsalReactTester {
 		 });
 	* });
 	*/
-	spyMsal() {
-		let eventId = 0;
-		this._testRunner.spyOn(this.client, 'addEventCallback').mockImplementation((callbackFn: any) => {
-			this._eventCallbacks.push(callbackFn);
-			eventId += 1;
-			return eventId.toString();
-		});
+  spyMsal() {
+    let eventId = 0;
+    this._testRunner
+      .spyOn(this.client, "addEventCallback")
+      .mockImplementation((callbackFn: any) => {
+        this._eventCallbacks.push(callbackFn);
+        eventId += 1;
+        return eventId.toString();
+      });
 
-		// send a message to say "hey we made redirect start then end"
-		this._handleRedirectSpy = this._testRunner.spyOn(this.client, 'handleRedirectPromise').mockImplementation(() => {
+    // send a message to say "hey we made redirect start then end"
+    this._handleRedirectSpy = this._testRunner
+      .spyOn(this.client, "handleRedirectPromise")
+      .mockImplementation(() => {
+        const eventStart: EventMessage = {
+          eventType: EventType.HANDLE_REDIRECT_START,
+          interactionType: InteractionType.Redirect,
+          payload: null,
+          error: null,
+          timestamp: 10000,
+        };
 
-			const eventStart: EventMessage = {
-				eventType: EventType.HANDLE_REDIRECT_START,
-				interactionType: InteractionType.Redirect,
-				payload: null,
-				error: null,
-				timestamp: 10000,
-			};
+        this._eventCallbacks.forEach((callback) => {
+          callback(eventStart);
+        });
 
+        const eventEnd: EventMessage = {
+          eventType: EventType.HANDLE_REDIRECT_END,
+          interactionType: InteractionType.Redirect,
+          payload: null,
+          error: null,
+          timestamp: 10000,
+        };
 
-			this._eventCallbacks.forEach((callback) => {
-				callback(eventStart);
-			});
+        this._eventCallbacks.forEach(async (callback) => {
+          callback(eventEnd);
+        });
 
+        return Promise.resolve(null);
+      });
 
-			const eventEnd: EventMessage = {
-				eventType: EventType.HANDLE_REDIRECT_END,
-				interactionType: InteractionType.Redirect,
-				payload: null,
-				error: null,
-				timestamp: 10000,
-			};
+    this._loginRedirectSpy = this._testRunner
+      .spyOn(this.client, "loginRedirect")
+      .mockImplementation(async (request: any) => {
+        this.accounts = [this._testAccountInfo];
+        this.activeAccount = this._testAccountInfo;
 
-			this._eventCallbacks.forEach(async (callback) => {
-				callback(eventEnd)
-			});
+        const eventMessage: EventMessage = {
+          eventType: EventType.LOGIN_SUCCESS,
+          interactionType: InteractionType.Redirect,
+          payload: this._testAuthenticationResult,
+          error: null,
+          timestamp: 10000,
+        };
 
-			return Promise.resolve(null);
-		});
+        this._eventCallbacks.forEach((callback) => {
+          callback(eventMessage);
+        });
 
-		this._loginRedirectSpy = this._testRunner.spyOn(this.client, 'loginRedirect').mockImplementation(async (request) => {
+        return Promise.resolve();
+      });
 
-			this.accounts = [this._testAccountInfo];
-			this.activeAccount = this._testAccountInfo;
+    this._loginPopupSpy = this._testRunner
+      .spyOn(this.client, "loginPopup")
+      .mockImplementation(async (request: any) => {
+        this.accounts = [this._testAccountInfo];
+        this.activeAccount = this._testAccountInfo;
 
-			const eventMessage: EventMessage = {
-				eventType: EventType.LOGIN_SUCCESS,
-				interactionType: InteractionType.Redirect,
-				payload: this._testAuthenticationResult,
-				error: null,
-				timestamp: 10000,
-			};
+        const eventMessage: EventMessage = {
+          eventType: EventType.LOGIN_SUCCESS,
+          interactionType: InteractionType.Popup,
+          payload: this._testAuthenticationResult,
+          error: null,
+          timestamp: 10000,
+        };
 
-			this._eventCallbacks.forEach((callback) => {
-				callback(eventMessage);
-			});
+        this._eventCallbacks.forEach((callback) => {
+          callback(eventMessage);
+        });
 
-			return Promise.resolve();
-		});
+        return Promise.resolve(this._testAuthenticationResult);
+      });
 
-		this._loginPopupSpy = this._testRunner.spyOn(this.client, "loginPopup").mockImplementation(async (request) => {
+    this._ssoSilentSpy = this._testRunner
+      .spyOn(this.client, "ssoSilent")
+      .mockImplementation(async (request: any) => {
+        this.accounts = [this._testAccountInfo];
+        this.activeAccount = this._testAccountInfo;
 
-			this.accounts = [this._testAccountInfo];
-			this.activeAccount = this._testAccountInfo;
+        const eventMessage: EventMessage = {
+          eventType: EventType.SSO_SILENT_SUCCESS,
+          interactionType: InteractionType.Silent,
+          payload: this._testAuthenticationResult,
+          error: null,
+          timestamp: 10000,
+        };
 
-			const eventMessage: EventMessage = {
-				eventType: EventType.LOGIN_SUCCESS,
-				interactionType: InteractionType.Popup,
-				payload: this._testAuthenticationResult,
-				error: null,
-				timestamp: 10000
-			};
+        this._eventCallbacks.forEach((callback) => {
+          callback(eventMessage);
+        });
 
-			this._eventCallbacks.forEach((callback) => {
-				callback(eventMessage);
-			});
+        return Promise.resolve(this._testAuthenticationResult);
+      });
 
-			return Promise.resolve(this._testAuthenticationResult);
-		});
+    this._logoutRedirectSpy = this._testRunner
+      .spyOn(this.client, "logoutRedirect")
+      .mockImplementation(async (request: any) => {
+        this.accounts = [];
+        this.activeAccount = null;
 
-		this._logoutRedirectSpy = this._testRunner.spyOn(this.client, 'logoutRedirect').mockImplementation(async (request) => {
-			this.accounts = [];
-			this.activeAccount = null;
+        const eventMessage: EventMessage = {
+          eventType: EventType.LOGOUT_SUCCESS,
+          interactionType: InteractionType.Redirect,
+          payload: this._testAuthenticationResult,
+          error: null,
+          timestamp: 10000,
+        };
 
-			const eventMessage: EventMessage = {
-				eventType: EventType.LOGOUT_SUCCESS,
-				interactionType: InteractionType.Redirect,
-				payload: this._testAuthenticationResult,
-				error: null,
-				timestamp: 10000,
-			};
+        this._eventCallbacks.forEach((callback) => {
+          callback(eventMessage);
+        });
 
-			this._eventCallbacks.forEach((callback) => {
-				callback(eventMessage);
-			});
+        return Promise.resolve();
+      });
 
-			return Promise.resolve();
+    this._logoutPopupSpy = this._testRunner
+      .spyOn(this.client, "logoutPopup")
+      .mockImplementation(async (request: any) => {
+        this.accounts = [];
+        this.activeAccount = null;
 
-		});
+        const eventMessage: EventMessage = {
+          eventType: EventType.LOGOUT_SUCCESS,
+          interactionType: InteractionType.Popup,
+          payload: this._testAuthenticationResult,
+          error: null,
+          timestamp: 10000,
+        };
 
-		this._logoutPopupSpy = this._testRunner.spyOn(this.client, 'logoutPopup').mockImplementation(async (request) => {
-			this.accounts = [];
-			this.activeAccount = null;
+        this._eventCallbacks.forEach((callback) => {
+          callback(eventMessage);
+        });
 
-			const eventMessage: EventMessage = {
-				eventType: EventType.LOGOUT_SUCCESS,
-				interactionType: InteractionType.Popup,
-				payload: this._testAuthenticationResult,
-				error: null,
-				timestamp: 10000,
-			};
+        return Promise.resolve();
+      });
 
-			this._eventCallbacks.forEach((callback) => {
-				callback(eventMessage);
-			});
+    this._testRunner
+      .spyOn(this.client, "getAllAccounts")
+      .mockImplementation(() => this.accounts);
+    this._testRunner
+      .spyOn(this.client, "getActiveAccount")
+      .mockImplementation(() => this.activeAccount);
+    this._testRunner
+      .spyOn(this.client, "setActiveAccount")
+      .mockImplementation(
+        (account: AccountInfo | null) => (this.activeAccount = account)
+      );
+  }
 
-			return Promise.resolve();
+  generateFailure() {
+    if (this.interationType === "Redirect") {
+      if (this._loginRedirectSpy) this._loginRedirectSpy.mockClear();
 
-		});
+      this._loginRedirectSpy = this._testRunner
+        .spyOn(this.client, "loginRedirect")
+        .mockImplementation(async (request: any) => {
+          const eventMessage: EventMessage = {
+            eventType: EventType.LOGIN_FAILURE,
+            interactionType: InteractionType.Redirect,
+            payload: null,
+            error: this.error,
+            timestamp: 10000,
+          };
 
-		this._testRunner.spyOn(this.client, 'getAllAccounts').mockImplementation(() => this.accounts);
-		this._testRunner.spyOn(this.client, 'getActiveAccount').mockImplementation(() => this.activeAccount);
-		this._testRunner.spyOn(this.client, 'setActiveAccount').mockImplementation((account) => (this.activeAccount = account));
-	}
+          this._eventCallbacks.forEach((callback) => {
+            callback(eventMessage);
+          });
 
+          return Promise.resolve();
+        });
+    } else if (this.interationType === "Popup") {
+      if (this._loginPopupSpy) this._loginPopupSpy.mockClear();
 
-	generateFailure() {
+      this._loginPopupSpy = this._testRunner
+        .spyOn(this.client, "loginPopup")
+        .mockImplementation(async () => {
+          const eventMessage: EventMessage = {
+            eventType: EventType.LOGIN_FAILURE,
+            interactionType: InteractionType.Popup,
+            payload: null,
+            error: this.error,
+            timestamp: 10000,
+          };
 
-		if (this.interationType === 'Redirect') {
+          this._eventCallbacks.forEach((callback) => {
+            callback(eventMessage);
+          });
 
-			if (this._loginRedirectSpy)
-				this._loginRedirectSpy.mockClear();
+          return Promise.resolve(null);
+        });
+    } else {
+      if (this._ssoSilentSpy) this._ssoSilentSpy.mockClear();
 
-			this._loginRedirectSpy = this._testRunner.spyOn(this.client, 'loginRedirect').mockImplementation(async (request) => {
+      this._ssoSilentSpy = this._testRunner
+        .spyOn(this.client, "ssoSilent")
+        .mockImplementation(async () => {
+          const eventMessage: EventMessage = {
+            eventType: EventType.SSO_SILENT_FAILURE,
+            interactionType: InteractionType.Silent,
+            payload: null,
+            error: this.error,
+            timestamp: 10000,
+          };
 
-				const eventMessage: EventMessage = {
-					eventType: EventType.LOGIN_FAILURE,
-					interactionType: InteractionType.Redirect,
-					payload: null,
-					error: this.error,
-					timestamp: 10000,
-				};
+          this._eventCallbacks.forEach((callback) => {
+            callback(eventMessage);
+          });
 
-				this._eventCallbacks.forEach((callback) => {
-					callback(eventMessage);
-				});
+          return Promise.resolve(null);
+        });
+    }
+  }
 
-				return Promise.resolve();
-			});
-		}
-		else {
+  static GetNewClient = (
+    testAccountInfo: AccountInfo,
+    testAuthenticationResult: AuthenticationResult
+  ): IPublicClientApplication => {
+    let logger = new Logger({
+      loggerCallback: (
+        _level: LogLevel,
+        _message: string,
+        _containsPii: boolean
+      ) => {},
+      piiLoggingEnabled: false,
+      logLevel: LogLevel.Error,
+      correlationId: "mock_test",
+    });
 
-			if (this._loginPopupSpy)
-				this._loginPopupSpy.mockClear();
-
-			this._loginPopupSpy = this._testRunner.spyOn(this.client, "loginPopup").mockImplementation(async () => {
-				const eventMessage: EventMessage = {
-					eventType: EventType.LOGIN_FAILURE,
-					interactionType: InteractionType.Popup,
-					payload: null,
-					error: this.error,
-					timestamp: 10000
-				};
-
-				this._eventCallbacks.forEach((callback) => {
-					callback(eventMessage);
-				});
-
-				return Promise.resolve(null);
-			});
-		}
-	}
-
-
-	static GetNewClient = (testAccountInfo: AccountInfo, testAuthenticationResult: AuthenticationResult): IPublicClientApplication => {
-		let logger = new Logger({
-			loggerCallback: (_level: LogLevel, _message: string, _containsPii: boolean) => { },
-			piiLoggingEnabled: false,
-			logLevel: LogLevel.Error,
-			correlationId: 'mock_test',
-		});
-
-		return {
-			initialize: () => Promise.resolve(),
-			acquireTokenPopup: () => Promise.resolve(testAuthenticationResult),
-			acquireTokenRedirect: () => Promise.resolve(),
-			acquireTokenSilent: () => Promise.resolve(testAuthenticationResult),
-			acquireTokenByCode: () => Promise.resolve(testAuthenticationResult),
-			getAllAccounts: () => [testAccountInfo],
-			getAccountByHomeId: () => testAccountInfo,
-			getAccountByUsername: () => testAccountInfo,
-			getAccountByLocalId: () => testAccountInfo,
-			handleRedirectPromise: () => Promise.resolve(testAuthenticationResult),
-			loginPopup: () => Promise.resolve(testAuthenticationResult),
-			loginRedirect: () => Promise.resolve(),
-			logout: () => Promise.resolve(),
-			logoutRedirect: () => Promise.resolve(),
-			logoutPopup: () => Promise.resolve(),
-			ssoSilent: () => Promise.resolve(testAuthenticationResult),
-			addEventCallback: () => null,
-			removeEventCallback: () => { return },
-			addPerformanceCallback: () => '',
-			removePerformanceCallback: () => false,
-			enableAccountStorageEvents: () => { return },
-			disableAccountStorageEvents: () => { return },
-			getTokenCache: () => null,
-			setLogger: (_l: Logger) => { return logger },
-			setActiveAccount: () => { return },
-			getActiveAccount: () => testAccountInfo,
-			initializeWrapperLibrary: () => { return },
-			setNavigationClient: () => { return },
-			getLogger: () => logger,
-			getConfiguration: () => null,
-		};
-	};
-
-
+    return {
+      initialize: () => Promise.resolve(),
+      acquireTokenPopup: () => Promise.resolve(testAuthenticationResult),
+      acquireTokenRedirect: () => Promise.resolve(),
+      acquireTokenSilent: () => Promise.resolve(testAuthenticationResult),
+      acquireTokenByCode: () => Promise.resolve(testAuthenticationResult),
+      getAllAccounts: () => [testAccountInfo],
+      getAccountByHomeId: () => testAccountInfo,
+      getAccountByUsername: () => testAccountInfo,
+      getAccountByLocalId: () => testAccountInfo,
+      handleRedirectPromise: () => Promise.resolve(testAuthenticationResult),
+      loginPopup: () => Promise.resolve(testAuthenticationResult),
+      loginRedirect: () => Promise.resolve(),
+      logout: () => Promise.resolve(),
+      logoutRedirect: () => Promise.resolve(),
+      logoutPopup: () => Promise.resolve(),
+      ssoSilent: () => Promise.resolve(testAuthenticationResult),
+      addEventCallback: () => null,
+      removeEventCallback: () => {
+        return;
+      },
+      addPerformanceCallback: () => "",
+      removePerformanceCallback: () => false,
+      enableAccountStorageEvents: () => {
+        return;
+      },
+      disableAccountStorageEvents: () => {
+        return;
+      },
+      getTokenCache: () => null as unknown as ITokenCache,
+      setLogger: (_l: Logger) => {
+        return logger;
+      },
+      setActiveAccount: () => {
+        return;
+      },
+      getActiveAccount: () => testAccountInfo,
+      initializeWrapperLibrary: () => {
+        return;
+      },
+      setNavigationClient: () => {
+        return;
+      },
+      getLogger: () => logger,
+      getConfiguration: () => null as unknown as BrowserConfiguration,
+    };
+  };
 }
-
 
 export default MsalReactTester;


### PR DESCRIPTION
Apologies for the formatting changes due to my auto linter and formatter, and this being my first time contributing to an open-source project. I will describe the main proposed changes below.

1. Add option for `"Silent"` interaction type in the constructor of `MsalReactTester`.
2. Add `_ssoSilentSpy` to spy on `ssoSilent` type logins.
3. Update `waitForLogin` to support `ssoSilent` type logins.
4. Update `waitForLogout` to default to using `logoutRedirect` when interaction type of `MsalReactTester` is `"Silent"`.

On an unrelated note, is the spelling of `interationType` parameter of `MsalReactTester` intentional? It does not affect users of the test package but may confuse maintainers/contributors.

Any feedback is appreciated! Thank you!