### PR TITLE
Add waitingFor instruction for vitest setup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ import { vi, expect } from 'vitest'
 MsalReactTesterPlugin.init({
   spyOn: vi.spyOn,
   expect: expect,
-  resetAllMocks: vi.resetAllMocks
+  resetAllMocks: vi.resetAllMocks,
+  waitingFor: waitFor
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ npm install --save-dev msal-react-tester
 
  ``` ts
 import { MsalReactTesterPlugin } from 'msal-react-tester'
+import { waitFor } from "@testing-library/react";
 import { vi, expect } from 'vitest'
 
 MsalReactTesterPlugin.init({


### PR DESCRIPTION
This PR adds the missing line in **vitest** section to set the waitingFor function.

 ``` ts
import { MsalReactTesterPlugin } from 'msal-react-tester'
import { waitFor } from "@testing-library/react";
import { vi, expect } from 'vitest'

MsalReactTesterPlugin.init({
  spyOn: vi.spyOn,
  expect: expect,
  resetAllMocks: vi.resetAllMocks,
  waitingFor: waitFor
})
```

This fixes #20.